### PR TITLE
Add BlackMarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ We did not make any of these scripts. We do not take any credits. Did we forget 
 - Giving items
 - Accounts support (bank, black money, ...)
 - Weapons support
+- Configurable Blackmarket (You can disable the blip on the map in the esx_inventoryhud/config.lua)
 - Property support
 - Motels support
 - Trunk support

--- a/esx_inventoryhud/client/shop.lua
+++ b/esx_inventoryhud/client/shop.lua
@@ -39,7 +39,7 @@ Citizen.CreateThread(function()
         Citizen.Wait(0)
         player = GetPlayerPed(-1)
         coords = GetEntityCoords(player)
-        if IsInRegularShopZone(coords) or IsInRobsLiquorZone(coords) or IsInYouToolZone(coords) or IsInPrisonShopZone(coords) or IsInWeaponShopZone(coords) or IsInWeaponAmmoPoliceZone(coords) or IsInWeaponAmmoNachtclubZone(coords) then
+        if IsInRegularShopZone(coords) or IsInRobsLiquorZone(coords) or IsInYouToolZone(coords) or IsInPrisonShopZone(coords) or IsInWeaponShopZone(coords) or IsInBlackMarketZone(coords) or IsInWeaponAmmoPoliceZone(coords) or IsInWeaponAmmoNachtclubZone(coords) then
             if IsInRegularShopZone(coords) then
                 if currentAction then
                     ESX.ShowHelpNotification(currentActionMsg)
@@ -77,7 +77,6 @@ Citizen.CreateThread(function()
                 end
             end
 			
-			
             if IsInWeaponShopZone(coords) then -- AMMUNITIE 
                 if currentAction then
                     ESX.ShowHelpNotification(currentActionMsg)
@@ -90,6 +89,16 @@ Citizen.CreateThread(function()
                                 exports['mythic_notify']:DoHudText('error', _U('license_check_fail'))
                             end
                         end, GetPlayerServerId(PlayerId()), 'weapon')
+                    end
+                end
+            end
+			
+			if IsInBlackMarketZone(coords) then
+                if currentAction then
+                    ESX.ShowHelpNotification(currentActionMsg)
+                    if IsControlJustReleased(0, Keys["E"]) then
+                        OpenShopInv("blackmarket")
+                        Citizen.Wait(2000)
                     end
                 end
             end
@@ -280,6 +289,16 @@ function IsInWeaponShopZone(coords)
     return false
 end
 
+function IsInBlackMarketZone(coords)
+    BlackMarket = Config.Shops.BlackMarket.Locations
+    for i = 1, #BlackMarket, 1 do
+        if GetDistanceBetweenCoords(coords, BlackMarket[i].x, BlackMarket[i].y, BlackMarket[i].z, true) < 1.5 then
+            return true
+        end
+    end
+    return false
+end
+
 function IsInWeaponAmmoPoliceZone(coords)
     WeaponShopPolice = Config.Shops.WeaponShopPolice.Locations
     for i = 1, #WeaponShopPolice, 1 do
@@ -372,6 +391,12 @@ Citizen.CreateThread(function()
     for k, v in pairs(Config.Shops.WeaponShop.Locations) do
         CreateBlip(vector3(Config.Shops.WeaponShop.Locations[k].x, Config.Shops.WeaponShop.Locations[k].y, Config.Shops.WeaponShop.Locations[k].z), _U('weapon_shop_name'), 3.0, Config.WeaponColor, Config.WeaponShopBlipID)
     end
+	
+	if Config.ShowBlackMarketBlip then
+		for k, v in pairs(Config.Shops.BlackMarket.Locations) do
+			CreateBlip(vector3(Config.Shops.BlackMarket.Locations[k].x, Config.Shops.BlackMarket.Locations[k].y, Config.Shops.BlackMarket.Locations[k].z), _U('blackmarket_shop_name'), 3.0, Config.BlackMarketColor, Config.BlackMarketBlipID)
+		end
+	end
 
     CreateBlip(vector3(-755.79, 5596.07, 41.67), "Cablecart", 3.0, 4, 36)
 end)
@@ -459,7 +484,13 @@ Citizen.CreateThread(function()
                 DrawMarker(25, Config.Shops.WeaponShop.Locations[k].x, Config.Shops.WeaponShop.Locations[k].y, Config.Shops.WeaponShop.Locations[k].z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Config.MarkerSize.x, Config.MarkerSize.y, Config.MarkerSize.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, nil, nil, false)
             end
         end
-
+		
+		for k, v in pairs(Config.Shops.BlackMarket.Locations) do
+            if GetDistanceBetweenCoords(coords, Config.Shops.BlackMarket.Locations[k].x, Config.Shops.BlackMarket.Locations[k].y, Config.Shops.BlackMarket.Locations[k].z + 0.01, true) < 12.0 then
+                DrawMarker(25, Config.Shops.BlackMarket.Locations[k].x, Config.Shops.BlackMarket.Locations[k].y, Config.Shops.BlackMarket.Locations[k].z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Config.MarkerSize.x, Config.MarkerSize.y, Config.MarkerSize.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, nil, nil, false)
+            end
+        end
+		
         for k, v in pairs(Config.Shops.WeaponShopNachtclub.Locations) do
             if GetDistanceBetweenCoords(coords, Config.Shops.WeaponShopNachtclub.Locations[k].x, Config.Shops.WeaponShopNachtclub.Locations[k].y, Config.Shops.WeaponShopNachtclub.Locations[k].z + 0.01, true) < 12.0 then
                 DrawMarker(25, Config.Shops.WeaponShopNachtclub.Locations[k].x, Config.Shops.WeaponShopNachtclub.Locations[k].y, Config.Shops.WeaponShopNachtclub.Locations[k].z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Config.MarkerSize.x, Config.MarkerSize.y, Config.MarkerSize.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, nil, nil, false)

--- a/esx_inventoryhud/config.lua
+++ b/esx_inventoryhud/config.lua
@@ -18,6 +18,10 @@ Config.PrisonShopBlipID = 52
 Config.WeedStoreBlipID = 140
 Config.WeaponShopBlipID = 110
 
+Config.ShowBlackMarketBlip = true -- True means the blackmarket will be marked on the map. False would hide it. 
+Config.BlackMarketBlipID = 110
+Config.BlackMarketColor = 1
+
 Config.ShopLength = 14
 Config.LiquorLength = 10
 Config.YouToolLength = 2
@@ -125,6 +129,26 @@ Config.Shops = {
 
         }
     },
+	
+	    BlackMarket = {
+        Locations = {
+            { x = -1297.96, y = -392.60, z = 35.47 },
+        
+        },
+        Weapons = {
+            {name = "WEAPON_ADVANCEDRIFLE", ammo = 45},
+            {name = "WEAPON_ASSAULTRIFLE", ammo = 45},
+        },
+        Ammo = {
+            {name = "WEAPON_ADVANCEDRIFLE_AMMO", weaponhash = "WEAPON_ADVANCEDRIFLE", ammo = 24},
+            {name = "WEAPON_ASSAULTRIFLE_AMMO", weaponhash = "WEAPON_ASSAULTRIFLE", ammo = 24},
+        },
+        Items = {
+		
+        }
+    },
+	
+
     LicenseShop = {
         Locations = {
             { x = 12.47, y = -1105.5, z = 29.8}

--- a/esx_inventoryhud/locales/en.lua
+++ b/esx_inventoryhud/locales/en.lua
@@ -29,6 +29,7 @@ Locales["en"] = {
     ['you_tool_name'] = 'Hardware store',
    	['prison_shop_name'] = 'Prison Commissioner',
 	['weapon_shop_name'] = 'AmmuNation',
+	['blackmarket_shop_name'] = 'BlackMarket',
 	['license_shop_title'] = 'Register License?',
 	['license_shop_help'] = 'press ~INPUT_CONTEXT~ to register license',
 	['license_shop_check'] = 'You already have a license to carry weapons!',

--- a/esx_inventoryhud/locales/fr.lua
+++ b/esx_inventoryhud/locales/fr.lua
@@ -26,6 +26,7 @@ Locales["fr"] = {
 	["you_tool_name"] = "Quincaillerie",
 	["prison_shop_name"] = "Magasin de Prison",
 	["weapon_shop_name"] = "Ammunation",
+	['blackmarket_shop_name'] = 'BlackMarket',
 	["license_shop_title"] = "Enregistrer une licence?",
 	["license_shop_help"] = "appuyez sur ~INPUT_CONTEXT~ pour enregistrer une licence.",
 	["license_shop_check"] = "Vous avez déjà une licence pour porter des armes!",

--- a/esx_inventoryhud/locales/nl.lua
+++ b/esx_inventoryhud/locales/nl.lua
@@ -26,6 +26,7 @@ Locales["nl"] = {
         ['you_tool_name'] = 'Bouwmarkt',
         ['prison_shop_name'] = 'Gevangenis winkel',
         ['weapon_shop_name'] = 'Wapenwinkel',
+		['blackmarket_shop_name'] = 'BlackMarket',
         ['license_shop_title'] = 'Licentie winkel',
         ['license_shop_help'] = 'Druk op ~INPUT_CONTEXT~ om de licentie winkel te openen',
         ['license_shop_check'] = 'Je hebt al een licentie om wapens te dragen!',

--- a/esx_inventoryhud/locales/pt.lua
+++ b/esx_inventoryhud/locales/pt.lua
@@ -29,6 +29,7 @@ Locales["pt"] = {
     ['you_tool_name'] = 'IKEA',
    	['prison_shop_name'] = 'Loja da Prisão',
 	['weapon_shop_name'] = 'Loja de Armas',
+	['blackmarket_shop_name'] = 'BlackMarket',
 	['license_shop_title'] = 'Registar licença?',
 	['license_shop_help'] = 'pressiona ~INPUT_CONTEXT~ para registar a licença',
 	['license_shop_check'] = 'Já tens uma licença de porte de Armas!',

--- a/esx_inventoryhud/locales/tr.lua
+++ b/esx_inventoryhud/locales/tr.lua
@@ -29,6 +29,7 @@ Locales["tr"] = {
     ['you_tool_name'] = 'Hırdavatçı',
    	['prison_shop_name'] = 'Hapishane Kantini',
 	['weapon_shop_name'] = 'Silahçı',
+	['blackmarket_shop_name'] = 'BlackMarket',
 	['license_shop_title'] = 'Silah Ruhsatı al?',
 	['license_shop_help'] = '~INPUT_CONTEXT~ ye basarak silah ruhsatı al',
 	['license_shop_check'] = 'Zaten silah taşıma ruhsatın var!',

--- a/esx_inventoryhud/server/main.lua
+++ b/esx_inventoryhud/server/main.lua
@@ -227,6 +227,58 @@ ESX.RegisterServerCallback("suku:getShopItems", function(source, cb, shoptype)
 				end
 			end
 		end
+		
+		if shoptype == "blackmarket" then
+			local weapons = Config.Shops.BlackMarket.Weapons
+			for _, v in pairs(Config.Shops.BlackMarket.Weapons) do
+				if v.name == itemResult[i].name then
+					table.insert(itemShopList, {
+						type = "item_weapon",
+						name = itemInformation[itemResult[i].name].name,
+						label = itemInformation[itemResult[i].name].label,
+						weight = 1,
+						ammo = v.ammo,
+						rare = itemInformation[itemResult[i].name].rare,
+						can_remove = itemInformation[itemResult[i].name].can_remove,
+						price = itemInformation[itemResult[i].name].price,
+						count = 99999999
+					})
+				end
+			end
+
+			local ammo = Config.Shops.BlackMarket.Ammo
+			for _,v in pairs(Config.Shops.BlackMarket.Ammo) do
+				if v.name == itemResult[i].name then
+					table.insert(itemShopList, {
+						type = "item_ammo",
+						name = itemInformation[itemResult[i].name].name,
+						label = itemInformation[itemResult[i].name].label,
+						weight = 1,
+						weaponhash = v.weaponhash,
+						ammo = v.ammo,
+						rare = itemInformation[itemResult[i].name].rare,
+						can_remove = itemInformation[itemResult[i].name].can_remove,
+						price = itemInformation[itemResult[i].name].price,
+						count = 99999999
+					})
+				end
+			end
+
+			for _, v in pairs(Config.Shops.BlackMarket.Items) do
+				if v.name == itemResult[i].name then
+					table.insert(itemShopList, {
+						type = "item_standard",
+						name = itemInformation[itemResult[i].name].name,
+						label = itemInformation[itemResult[i].name].label,
+						weight = itemInformation[itemResult[i].name].weight,
+						rare = itemInformation[itemResult[i].name].rare,
+						can_remove = itemInformation[itemResult[i].name].can_remove,
+						price = itemInformation[itemResult[i].name].price,
+						count = 99999999
+					})
+				end
+			end
+		end
 	end
 	cb(itemShopList)
 end)


### PR DESCRIPTION
Added a blackmarket configuration.
You can enable/disable the blip in the config.

Will remove the need for servers to use esx_weaponshop for their blackmarket weapons.
And you can even add items into it 😉 