### PR TITLE
Fix broken reload system

### DIFF
--- a/ESX Inventory HUD/DP_Inventory/client/ammunition.lua
+++ b/ESX Inventory HUD/DP_Inventory/client/ammunition.lua
@@ -10,10 +10,12 @@ RegisterNetEvent('ammunition:useAmmoItem')
 AddEventHandler('ammunition:useAmmoItem', function(ammo)
 	local playerPed = GetPlayerPed(-1)
 	local weapon
-	local found, currentWeapon = GetCurrentPedWeapon(playerPed, true)
+	local found, currentWeaponHash = GetCurrentPedWeapon(playerPed, true)
+
 	if found then
 		for _, v in pairs(ammo.weapons) do
-			if currentWeapon == v then
+			local weaponHash = GetHashKey(v)
+			if currentWeaponHash == weaponHash then
 				weapon = v
 				break
 			end


### PR DESCRIPTION
GetCurrentPedWeapon(playerPed, true) returns a weapon hash number whereas ammo.weapons has string valus of the weapon name like WEAPON_CARBINERIFLE. None of our weapons would reload and the reason is **weapon ~= nil** on line 23 always failed because **if currentWeapon == v then** was always false, you can't expect true from comparing number to string. You need the weapon hash of the weapon being compared from the config file. Perhaps at one time in the past you did have the weapon hashes in the config file instead?
I've changed this to compare hashes on both sides so that **weapon = v** assignment CAN now be called and reload now works for us