### PR TITLE
Fixed Error Dup Key

### DIFF
--- a/ESX Inventory HUD/DupKeyFix.sql
+++ b/ESX Inventory HUD/DupKeyFix.sql
@@ -1,0 +1,4 @@
+ALTER TABLE addon_account_data
+MODIFY owner VARCHAR(60);
+ALTER TABLE addon_inventory_items
+MODIFY owner VARCHAR(60);


### PR DESCRIPTION
This error I think is caused because if you have set your primary identifier in ExM or Es Extended to license the length of that should be 60 or your license is longer than 40. This has fixed it for me! The main problem is that it's comparing a value with another that is longer than 40. This shouldn't appear if the primary identifier is steam I think they shouldn't be any errors ty for all. Have a nice day!