### PR TITLE
Fix Column 'owner' cannot be null.

### DIFF
--- a/ESX/Inventory HUD/UPLOAD TO YOUR DATABASE.sql
+++ b/ESX/Inventory HUD/UPLOAD TO YOUR DATABASE.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `inventory_trunk` (
 
 CREATE TABLE IF NOT EXISTS `ammunition` (
     `id` bigint unsigned auto_increment PRIMARY KEY,
-    `owner` text not null,
+    `owner` text,
 	`original_owner` text not null,
     `hash` text not null,
 	`weapon_id` char(60) NOT NULL,


### PR DESCRIPTION
When you remove a weapon from inventory, it is updated in the database as a null value, but the SQL file does not allow null values.
[Error image](https://user-images.githubusercontent.com/39607799/102736221-22b2ed80-4323-11eb-9ac8-829d970f48af.png)