### PR TITLE
Remove 'item_used' notification when using a weapon from hotbar

### DIFF
--- a/ESX/Inventory HUD/DP_Inventory/client/main.lua
+++ b/ESX/Inventory HUD/DP_Inventory/client/main.lua
@@ -82,27 +82,27 @@ Citizen.CreateThread(function()
 			elseif  IsDisabledControlJustReleased(1, 157) and canFire then
 				if fastWeapons[1] ~= nil then
 					TriggerServerEvent("esx:useItem", fastWeapons[1])
-					TriggerEvent('DP_Inventory:notification', fastWeapons[1], _U("item_used"), 1, false)
+					if not string.find(fastWeapons[1], "WEAPON_", 1) then TriggerEvent('DP_Inventory:notification', fastWeapons[1], _U("item_used"), 1, false) end
 				end
 			elseif IsDisabledControlJustReleased(1, 158) and canFire then
 				if fastWeapons[2] ~= nil then
 					TriggerServerEvent("esx:useItem", fastWeapons[2])
-					TriggerEvent('DP_Inventory:notification', fastWeapons[2], _U("item_used"), 1, false)
+					if not string.find(fastWeapons[2], "WEAPON_", 1) then TriggerEvent('DP_Inventory:notification', fastWeapons[2], _U("item_used"), 1, false) end
 				end
 			elseif IsDisabledControlJustReleased(1, 160) and canFire then
 				if fastWeapons[3] ~= nil then
 					TriggerServerEvent("esx:useItem", fastWeapons[3])
-					TriggerEvent('DP_Inventory:notification', fastWeapons[3], _U("item_used"), 1, false)
+					if not string.find(fastWeapons[3], "WEAPON_", 1) then TriggerEvent('DP_Inventory:notification', fastWeapons[3], _U("item_used"), 1, false) end
 				end
 			elseif IsDisabledControlJustReleased(1, 164) and canFire then
 				if fastWeapons[4] ~= nil then
 					TriggerServerEvent("esx:useItem", fastWeapons[4])
-					TriggerEvent('DP_Inventory:notification', fastWeapons[4], _U("item_used"), 1, false)
+					if not string.find(fastWeapons[4], "WEAPON_", 1) then TriggerEvent('DP_Inventory:notification', fastWeapons[4], _U("item_used"), 1, false) end
 				end
-			elseif IsDisabledControlJustReleased(1, 165) and canFire then
+			elseif IsDisabledControlJustReleased(4, 165) and canFire then
 				if fastWeapons[5] ~= nil then
 					TriggerServerEvent("esx:useItem", fastWeapons[5])
-					TriggerEvent('DP_Inventory:notification', fastWeapons[5], _U("item_used"), 1, false)
+					if not string.find(fastWeapons[5], "WEAPON_", 1) then TriggerEvent('DP_Inventory:notification', fastWeapons[5], _U("item_used"), 1, false) end
 				end
 			elseif IsDisabledControlJustReleased(1, 37) then
 				HudForceWeaponWheel(false)


### PR DESCRIPTION
Using items from the hotbar will only send the 'item_used' notification if fastWeapon[i] does not contain "WEAPON_".
'weapon_pulled' and 'weapon_used' are separate notifications which are still sent.