### PR TITLE
loadPlayerInventory() after PlayerData is retrieved

### DIFF
--- a/ESX/Inventory HUD/DP_Inventory/client/main.lua
+++ b/ESX/Inventory HUD/DP_Inventory/client/main.lua
@@ -19,6 +19,7 @@ Citizen.CreateThread(function()
 	while ESX == nil do TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end) Citizen.Wait(0) end
 	while ESX.GetPlayerData().job == nil do Citizen.Wait(10) end
 	PlayerData = ESX.GetPlayerData()
+	loadPlayerInventory()
 	Citizen.Wait(3000)
 end)
 


### PR DESCRIPTION
Load the player inventory so hotbar and fastWeapons work without having opened the inventory first