### PR TITLE
Fix: Removed depreciated t-notify code.

### DIFF
--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/player.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/player.lua
@@ -45,10 +45,18 @@ Citizen.CreateThread(function()
 								end
 							end)
 						else
-							exports['t-notify']:SendTextAlert('info', _U('player_not_dead'), 5500, false)
+							exports['t-notify']:Alert({
+								style  	=  'info',
+								message =  _U('player_not_dead'),
+								length 	= 5500
+							})
 						end
 					else
-						exports['t-notify']:SendTextAlert('info', _U('no_permissions'), 5500, false)
+						exports['t-notify']:Alert({
+							style  	=  'info',
+							message =  _U('no_permissions'),
+							length 	= 5500
+						})
 					end
 				else
 					local searchPlayerPed = GetPlayerPed(closestPlayer)
@@ -68,7 +76,11 @@ Citizen.CreateThread(function()
 							end
 						end)  
 					else
-						exports['t-notify']:SendTextAlert('info', _U('player_not_dead'), 5500, false)
+						exports['t-notify']:Alert({
+							style  	=  'info',
+							message =  _U('player_not_dead'),
+							length 	= 5500
+						})
 					end
 				end
             end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/shop.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/shop.lua
@@ -20,7 +20,11 @@ RegisterKey('keyboard', 'E',
 						if ESX.GetPlayerData().job.name == Config.InventoryJob.Police then
 							OpenShopInv('ilegal')
 						else
-							exports['t-notify']:SendTextAlert('info', _U('no_acces'), 5500, false)
+							exports['t-notify']:Alert({
+								style  	=  'error',
+								message =  _U('no_acces'),
+								length 	= 5500
+							})
 						end
 					end
 				end
@@ -31,8 +35,11 @@ RegisterKey('keyboard', 'E',
 							if ja then
 								OpenShopInv('groothandel_supermarkt')
 							else
-								--exports['mythic_notify']:DoHudText('error', 'Je beheert geen eigen winkel')
-								exports['t-notify']:SendTextAlert('info', _U('no_acces'), 5500, false)
+								exports['t-notify']:Alert({
+									style  	=  'error',
+									message =  _U('no_acces'),
+									length 	= 5500
+								})
 							end
 						end, GetPlayerServerId(PlayerId()))
 					end
@@ -62,7 +69,11 @@ RegisterKey('keyboard', 'E',
 							if hasWeaponLicense then
 								OpenShopInv('weaponshop')
 							else
-								exports['t-notify']:SendTextAlert('info', _U('license_check_fail'), 5500, false)
+								exports['t-notify']:Alert({
+									style  	=  'error',
+									message =  _U('license_check_fail'),
+									length 	= 5500
+								})
 							end
 						end, GetPlayerServerId(PlayerId()), Config.License.Weapon)
 					else
@@ -634,7 +645,11 @@ if Config.UseLicense then
 							if IsControlJustReleased(0, 38) then
 								ESX.TriggerServerCallback('esx_license:checkLicense', function(hasWeaponLicense)
 								if hasWeaponLicense then
-									exports['t-notify']:SendTextAlert('info', _U('license_shop_check'), 5500, false)
+									exports['t-notify']:Alert({
+										style  	=  'error',
+										message =  _U('license_shop_check'),
+										length 	= 5500
+									})
 								else
 									OpenBuyLicenseMenu()
 									Citizen.Wait(2000)

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/shop.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/addons/shop.lua
@@ -126,8 +126,12 @@ RegisterKey('keyboard', 'E',
 						if ESX.GetPlayerData().job.name == Config.InventoryJob.Police then
 							OpenShopInv('ilegal')
 							Citizen.Wait(2000)
-						else
-							exports['mythic_notify']:DoHudText('error', _U('no_acces'))
+						else					
+							exports['t-notify']:Alert({
+								style  	=  'error',
+								message =  _U('no_acces'),
+								length 	= 5500
+							})
 						end
 					end
 				end
@@ -138,7 +142,11 @@ RegisterKey('keyboard', 'E',
 						if hasWeaponLicense then
 							OpenShopInv('groothandel_supermarkt')
 						else
-							exports['mythic_notify']:DoHudText('error', 'Je beheert geen eigen winkel')
+							exports['t-notify']:Alert({
+								style  	=  'error',
+								message =  'Je beheert geen eigen winkel',
+								length 	= 5500
+							})
 						end
 					end, GetPlayerServerId(PlayerId()))
 				end
@@ -177,7 +185,11 @@ RegisterKey('keyboard', 'E',
 								OpenShopInv('weaponshop')
 								Citizen.Wait(2000)
 							else
-								exports['mythic_notify']:DoHudText('error', _U('license_check_fail'))
+								exports['t-notify']:Alert({
+									style  	=  'error',
+									message =  _U('license_check_fail'),
+									length 	= 5500
+								})								
 							end
 						end, GetPlayerServerId(PlayerId()), Config.License.Weapon)
 					else

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/ammunition.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/ammunition.lua
@@ -55,9 +55,17 @@ AddEventHandler('ammunition:useAmmoItem', function(ammo)
 				SetPedAmmo(playerPed, weapon, newAmmo)
 				TriggerServerEvent('ammunition:removeAmmoItem', ammo)
 				TaskReloadWeapon(playerPed)
-				exports['t-notify']:SendTextAlert('info', _U('reloaded'), 5500, false)
+				exports['t-notify']:Alert({
+					style  	=  'info',
+					message =  _U('reloaded'),
+					length 	= 5500
+				})
 			else
-				exports['t-notify']:SendTextAlert('error', _U('max_ammo'), 5500, false)
+				exports['t-notify']:Alert({
+					style  	=  'error',
+					message =  _U('max_ammo'),
+					length 	= 5500
+				})
 			end
 		end
 	end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/glovebox.lua
@@ -105,13 +105,22 @@ function openGlovebox()
 						end)
 					end
 				else
-					exports['t-notify']:SendTextAlert('info', _U('no_veh_nearby'), 5500, false)
+					exports['t-notify']:Alert({
+						style  	=  'info',
+						message =  _U('no_veh_nearby'),
+						length 	= 5500
+					})
 				end
 				lastOpen = true
 				GUI.Time = GetGameTimer()
 			end
 		else
-			exports['t-notify']:SendTextAlert('info', _U('nacho_veh'), 5500, false)
+			exports['t-notify']:Alert({
+				style  	=  'error',
+				message =  _U('nacho_veh'),
+				length 	= 5500
+			})
+			
 		end
 	end
 end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/trunk.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/trunk.lua
@@ -85,8 +85,20 @@ function openTrunk()
 				local vehFront = VehicleInFront()
 				vehHash = GetEntityModel(vehFront)
 				checkVehicle = vehStorage[vehHash]
-				if checkVehicle == 1 then open, vehBone = 4, GetEntityBoneIndexByName(vehFront, 'bonnet')
-				elseif checkVehicle == nil then open, vehBone = 5, GetEntityBoneIndexByName(vehFront, 'boot') elseif checkVehicle == 2 then open, vehBone = 5, GetEntityBoneIndexByName(vehicle, 'boot') else exports['t-notify']:SendTextAlert('info', _U('no_veh_nearby'), 5500, false) return end
+				if checkVehicle == 1 then 
+					open, vehBone = 4, GetEntityBoneIndexByName(vehFront, 'bonnet')
+				elseif checkVehicle == nil then 
+					open, vehBone = 5, GetEntityBoneIndexByName(vehFront, 'boot') 
+				elseif checkVehicle == 2 then 
+					open, vehBone = 5, GetEntityBoneIndexByName(vehicle, 'boot') 
+				else
+					exports['t-notify']:Alert({
+						style  	=  'error',
+						message =  _U('no_veh_nearby'),
+						length 	= 5500
+					})
+					return 
+				end
 				local vehiclePos = GetWorldPositionOfEntityBone(vehFront, vehBone)
 		
 				local pedDistance = GetDistanceBetweenCoords(vehiclePos, coords, 1)
@@ -124,23 +136,39 @@ function openTrunk()
 												loadCamera(0, 3)
 											end
 										else
-											exports['t-notify']:SendTextAlert('error', _U('trunk_closed'), 5500, false)
+											exports['t-notify']:Alert({
+												style  	=  'error',
+												message =  _U('trunk_closed'),
+												length 	= 5500
+											})
 										end
 									end
 								end)
 							end
 						else
-							exports['t-notify']:SendTextAlert('error', _U('trunk_closed'), 5500, false)
+							exports['t-notify']:Alert({
+								style  	=  'error',
+								message =  _U('trunk_closed'),
+								length 	= 5500
+							})
 						end
 					end
 				else
-					exports['t-notify']:SendTextAlert('error', _U('no_veh_nearby'), 5500, false)
+					exports['t-notify']:Alert({
+						style  	=  'error',
+						message =  _U('no_veh_nearby'),
+						length 	= 5500
+					})
 				end
 				lastOpen = true
 				GUI.Time = GetGameTimer()
 			end
 		else
-			exports['t-notify']:SendTextAlert('error', _U('nacho_veh'), 5500, false)
+			exports['t-notify']:Alert({
+				style  	=  'error',
+				message =  _U('nacho_veh'),
+				length 	= 5500
+			})
 		end
 	end
 end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/vault.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/vault.lua
@@ -29,14 +29,22 @@ function OpenVaultInventoryMenu(data)
 		vaultType = data
 		ESX.TriggerServerCallback("DP_Inventory:getVaultInventory", function(inventory)
 			if not inventory then
-				exports['t-notify']:SendTextAlert('error', _U('not_found'), 5500, false)
+				exports['t-notify']:Alert({
+					style  	=  'error',
+					message =  _U('not_found'),
+					length 	= 5500
+				})
 			else
 				TriggerEvent("DP_Inventory:openVaultInventory", inventory)
 			end
 		end,
 		data)
 	else
-		exports['t-notify']:SendTextAlert('error', _U('no_key'), 5500, false)
+		exports['t-notify']:Alert({
+			style  	=  'error',
+			message =  _U('no_key'),
+			length 	= 5500
+		})
 		Citizen.Wait(0)
 	end
 end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/weapons.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/client/weapons.lua
@@ -153,10 +153,18 @@ AddEventHandler('DP_Inventory:useAttach', function(attach)
                 end
             end, attach)
         else
-			exports['t-notify']:SendTextAlert('info', _U("not_compatible"), 5500, false)
+            exports['t-notify']:Alert({
+                style  	=  'error',
+                message =  _U("not_compatible"),
+                length 	= 5500
+            })
         end
     else
-		exports['t-notify']:SendTextAlert('info', _U("no_weapon_selected"), 5500, false)
+        exports['t-notify']:Alert({
+            style  	=  'error',
+            message =  _U("no_weapon_selected"),
+            length 	= 5500
+        })
     end
 end)
 
@@ -196,7 +204,11 @@ RegisterKey('keyboard',"BACKSLASH",
                     end
                 end
             else
-				exports['t-notify']:SendTextAlert('info', _U("no_gun_in_hand"), 5500, false)
+                exports['t-notify']:Alert({
+                    style  	=  'error',
+                    message =  _U("no_gun_in_hand"),
+                    length 	= 5500
+                })
             end
 		end
 	end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
@@ -239,7 +239,7 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 						end
 						break
 						else
-							TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+							TriggerClientEvent('t-notify:client:Alert', _source, {
 								style  =  'success',
 								duration  =  5500,
 								message = _U("nacho_veh"),
@@ -279,7 +279,7 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 				TriggerClientEvent("DP_Inventory:refreshGloveboxInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("player_inv_no_space"),
@@ -405,7 +405,7 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 					})
 				end
 				if (getTotalInventoryWeightGlovebox(plate) + (count / 10)) > max then
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  5500,
 						message = _U("insufficient_space"),
@@ -427,7 +427,7 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_quantity"),
@@ -460,7 +460,7 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_amount"),
@@ -481,7 +481,7 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 					table.insert(cashMoney, {amount = count})
 				end
 				if (getTotalInventoryWeightGlovebox(plate) + (count / 10)) > max then
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  5500,
 						message = _U("insufficient_space"),
@@ -497,7 +497,7 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_amount"),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
@@ -321,12 +321,10 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 				data = {plate = plate, max = max, myVeh = owned, text = text}
 				TriggerClientEvent("DP_Inventory:refreshGloveboxInventory", _source, data, blackMoney, items, weapons)
 			else
-				TriggerClientEvent("pNotify:SendNotification", _source, {
-					text = _U("invalid_amount"),
-					type = "error",
-					queue = "glovebox",
-					timeout = 3000,
-					layout = "bottomCenter"
+				TriggerClientEvent('t-notify:client:Alert', _source, {
+					style 		=  'error',
+					duration 	=  5500,
+					message 	= _U("invalid_amount"),
 				})
 			end
 		end)
@@ -367,12 +365,10 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 				data = {plate = plate, max = max, myVeh = owned, text = text}
 				TriggerClientEvent("DP_Inventory:refreshGloveboxInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			else
-				TriggerClientEvent("pNotify:SendNotification", _source, {
-					text = _U("invalid_amount"),
-					type = "error",
-					queue = "glovebox",
-					timeout = 3000,
-					layout = "bottomCenter"
+				TriggerClientEvent('t-notify:client:Alert', _source, {
+					style 		=  'error',
+					duration 	=  5500,
+					message 	= _U("invalid_amount"),
 				})
 			end
 		end)

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
@@ -240,10 +240,10 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 						break
 						else
 							TriggerClientEvent('t-notify:client:Alert', _source, {
-								style  =  'success',
-								duration  =  5500,
-								message = _U("nacho_veh"),
-								sound  =  true
+								style  		=  'success',
+								duration  	=  5500,
+								message 	= _U("nacho_veh"),
+								sound  		=  true
 							})
 						end
 					end
@@ -280,10 +280,10 @@ AddEventHandler("DP_Inventory_glovebox:getItem", function(plate, type, item, cou
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("player_inv_no_space"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("player_inv_no_space"),
+				sound  		=  true
 			})
 		end
 	end
@@ -406,10 +406,10 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 				if (getTotalInventoryWeightGlovebox(plate) + (count / 10)) > max then
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  5500,
-						message = _U("insufficient_space"),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  5500,
+						message 	= _U("insufficient_space"),
+						sound  		=  true
 					})
 				else
 					store.set("coffres", coffres)
@@ -428,10 +428,10 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("invalid_quantity"),
-				sound  =  true
+				style 		=  'success',
+				duration  	=  5500,
+				message 	= _U("invalid_quantity"),
+				sound  		=  true
 			})
 		end
 	end
@@ -461,10 +461,10 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("invalid_amount"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("invalid_amount"),
+				sound  		=  true
 			})
 		end
 	end
@@ -482,10 +482,10 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 				if (getTotalInventoryWeightGlovebox(plate) + (count / 10)) > max then
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  5500,
-						message = _U("insufficient_space"),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  5500,
+						message 	= _U("insufficient_space"),
+						sound  		=  true
 					})
 				else
 					xPlayer.removeMoney(count)
@@ -498,10 +498,10 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("invalid_amount"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("invalid_amount"),
+				sound  		=  true
 			})
 		end
 	end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
@@ -445,7 +445,12 @@ AddEventHandler("DP_Inventory_glovebox:putItem", function(plate, type, item, cou
 				end
 
 				if (getTotalInventoryWeightGlovebox(plate) + blackMoney[1].amount / 10) > max then
-					TriggerClientEvent('b1g_notify:client:Notify', _source, { type = 'true', text = _U("insufficient_space") })
+					TriggerClientEvent('t-notify:client:Alert', _source, {
+						style 		=  'error',
+						duration  	=  5500,
+						message 	= _U("insufficient_space"),
+						sound  		=  true
+					})
 				else
 					xPlayer.removeAccountMoney(item, count)
 					store.set("black_money", blackMoney)

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/lockers.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/lockers.lua
@@ -26,14 +26,14 @@ AddEventHandler('DP_Inventory:startRentingLocker', function(lockerId, lockerName
 					['@lockerId'] = lockerId
 				})
 				xPlayer.removeMoney(Config.InitialLockerRentPrice)
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'success',
 					duration  =  5500,
 					message = 'Je huurt nu kluis ' ..lockerName.. '. Dat kost dan €'..Config.DailyRentPrice..' dagelijks (IRL)',
 					sound  =  true
 				})
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('no_money_locker'),
@@ -41,7 +41,7 @@ AddEventHandler('DP_Inventory:startRentingLocker', function(lockerId, lockerName
 				})
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('already_locker'),
@@ -61,14 +61,14 @@ AddEventHandler('DP_Inventory:stopRentingLocker', function(lockerId, lockerName)
 				['@lockerId'] = lockerId,
 				['@identifier'] = xPlayer.identifier
 			})
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'succes',
 				duration  =  5500,
 				message = _U('canceled_locker'),
 				sound  =  true
 			})
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('dont_own_locker'),
@@ -130,7 +130,7 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 			
 				-- can the player carry the said amount of x item?
 				if not xPlayer.canCarryItem(sourceItem.name, sourceItem.count + count) then
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('insufficient_space'),
@@ -139,7 +139,7 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 				else
 					inventory.removeItem(item, count)
 					xPlayer.addInventoryItem(item, count)
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('you_took') ..count..'x '..inventoryItem.label..'',
@@ -147,7 +147,7 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 					})
 				end
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('not_in_locker'),
@@ -165,7 +165,7 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('invalid_quantity'),
@@ -181,7 +181,7 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('invalid_quantity'),
@@ -206,7 +206,7 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 			TriggerEvent('esx_addoninventory:getInventory', 'locker', xPlayerOwner.identifier, function(inventory)
 				xPlayer.removeInventoryItem(item, count)
 				inventory.addItem(item, count)
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'inform',
 					duration  =  5500,
 					message = _U('you_put')..count..'x '..inventory.getItem(item).label..'',
@@ -214,7 +214,7 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 				})
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('invalid_quantity'),
@@ -233,7 +233,7 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 					account.addMoney(count)
 				end)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('invalid_quantity'),
@@ -250,7 +250,7 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 					account.addMoney(count)
 				end)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('invalid_quantity'),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/lockers.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/lockers.lua
@@ -27,25 +27,25 @@ AddEventHandler('DP_Inventory:startRentingLocker', function(lockerId, lockerName
 				})
 				xPlayer.removeMoney(Config.InitialLockerRentPrice)
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'success',
-					duration  =  5500,
-					message = 'Je huurt nu kluis ' ..lockerName.. '. Dat kost dan €'..Config.DailyRentPrice..' dagelijks (IRL)',
-					sound  =  true
+					style  		=  'success',
+					duration  	=  5500,
+					message 	= 'Je huurt nu kluis ' ..lockerName.. '. Dat kost dan €'..Config.DailyRentPrice..' dagelijks (IRL)',
+					sound  		=  true
 				})
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('no_money_locker'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('no_money_locker'),
+					sound  		=  true
 				})
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('already_locker'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('already_locker'),
+				sound  		=  true
 			})
 		end
 	end)
@@ -62,17 +62,17 @@ AddEventHandler('DP_Inventory:stopRentingLocker', function(lockerId, lockerName)
 				['@identifier'] = xPlayer.identifier
 			})
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'succes',
-				duration  =  5500,
-				message = _U('canceled_locker'),
-				sound  =  true
+				style  		=  'succes',
+				duration  	=  5500,
+				message 	= _U('canceled_locker'),
+				sound  		=  true
 			})
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('dont_own_locker'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('dont_own_locker'),
+				sound  		=  true
 			})
 		end
 	end)
@@ -85,7 +85,11 @@ function PayLockerRent(d, h, m)
 			local xPlayer = ESX.GetPlayerFromIdentifier(result[i].owner)
 			if xPlayer then
 				xPlayer.removeAccountMoney('bank', Config.DailyLockerRentPrice)
-				TriggerClientEvent('mythic_notify:client:SendAlert', xPlayer.source, { type = 'inform', text = 'Je betaalde €'..Config.DailyLockerRentPrice..' voor de verhuur van kluisjes.', length = 8000 })
+				TriggerClientEvent('t-notify:client:Alert', xPlayer.source, {
+					style  		=  'info',
+					duration  	=  8000,
+					message 	= 'Je betaalde €'..Config.DailyLockerRentPrice..' voor de verhuur van kluisjes.'
+				})
 			else
 				if oldESX then
 					MySQL.Sync.execute('UPDATE users SET bank = bank - @bank WHERE owner = @identifier', { ['@bank'] = Config.DailyLockerRentPrice, ['@identifier'] = owner })
@@ -131,27 +135,27 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 				-- can the player carry the said amount of x item?
 				if not xPlayer.canCarryItem(sourceItem.name, sourceItem.count + count) then
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('insufficient_space'),
-						sound  =  true
+						style 	 	=  'error',
+						duration  	=  5500,
+						message 	= _U('insufficient_space'),
+						sound  		=  true
 					})
 				else
 					inventory.removeItem(item, count)
 					xPlayer.addInventoryItem(item, count)
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('you_took') ..count..'x '..inventoryItem.label..'',
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('you_took') ..count..'x '..inventoryItem.label..'',
+						sound  		=  true
 					})
 				end
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('not_in_locker'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('not_in_locker'),
+					sound  		=  true
 				})
 			end
 		end)
@@ -166,10 +170,10 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 					xPlayer.addAccountMoney(item, count)
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('invalid_quantity'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('invalid_quantity'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -182,10 +186,10 @@ AddEventHandler('DP_Inventory:getLockerItems', function(owner, type, item, count
 					xPlayer.addAccountMoney(item, count)
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('invalid_quantity'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('invalid_quantity'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -207,18 +211,18 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 				xPlayer.removeInventoryItem(item, count)
 				inventory.addItem(item, count)
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'inform',
-					duration  =  5500,
-					message = _U('you_put')..count..'x '..inventory.getItem(item).label..'',
-					sound  =  true
+					style  		=  'inform',
+					duration  	=  5500,
+					message 	= _U('you_put')..count..'x '..inventory.getItem(item).label..'',
+					sound  		=  true
 				})
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('invalid_quantity'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('invalid_quantity'),
+				sound  		=  true
 			})
 		end
 
@@ -234,10 +238,10 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 				end)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('invalid_quantity'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('invalid_quantity'),
+					sound  		=  true
 				})
 			end
 		else
@@ -251,10 +255,10 @@ AddEventHandler('DP_Inventory:putLockerItems', function(owner, type, item, count
 				end)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('invalid_quantity'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('invalid_quantity'),
+					sound  		=  true
 				})
 			end
 		end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/main.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/main.lua
@@ -22,10 +22,10 @@ RegisterCommand("openinventory", function(source, args, rawCommand) -- ADMIN WAT
 			TriggerClientEvent("DP_Inventory:openPlayerInventory", source, target, targetXPlayer.name)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('no_player'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('no_player'),
+				sound  		=  true
 			})
 		end
 	else
@@ -34,18 +34,18 @@ RegisterCommand("openinventory", function(source, args, rawCommand) -- ADMIN WAT
 				TriggerClientEvent("DP_Inventory:openPlayerInventory", source, target, targetXPlayer.name)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('no_permissions'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('no_permissions'),
+					sound  		=  true
 				})
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('no_permissions'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('no_permissions'),
+				sound 		 =  true
 			})
 		end
 	end
@@ -134,10 +134,10 @@ AddEventHandler("DP_Inventory:tradePlayerItem", function(from, target, type, ite
 				targetXPlayer.addInventoryItem(itemName, itemCount)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('player_inv_no_space'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('player_inv_no_space'),
+					sound  		=  true
 				})
 			end
 		end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/main.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/main.lua
@@ -21,7 +21,7 @@ RegisterCommand("openinventory", function(source, args, rawCommand) -- ADMIN WAT
 		if targetXPlayer ~= nil then
 			TriggerClientEvent("DP_Inventory:openPlayerInventory", source, target, targetXPlayer.name)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('no_player'),
@@ -33,7 +33,7 @@ RegisterCommand("openinventory", function(source, args, rawCommand) -- ADMIN WAT
 			if (Config.AllowPolice and xPlayer.job.name == Config.InventoryJob.Police) or (Config.AllowNightclub and xPlayer.job.name == Config.InventoryJob.Nightclub) or (Config.AllowMafia and xPlayer.job.name == Config.InventoryJob.Mafia) or (Config.AllowMafia and xPlayer.job.name == Config.InventoryJob.Ambulance) then
 				TriggerClientEvent("DP_Inventory:openPlayerInventory", source, target, targetXPlayer.name)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('no_permissions'),
@@ -41,7 +41,7 @@ RegisterCommand("openinventory", function(source, args, rawCommand) -- ADMIN WAT
 				})
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('no_permissions'),
@@ -133,7 +133,7 @@ AddEventHandler("DP_Inventory:tradePlayerItem", function(from, target, type, ite
 				sourceXPlayer.removeInventoryItem(itemName, itemCount)
 				targetXPlayer.addInventoryItem(itemName, itemCount)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('player_inv_no_space'),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/shop.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/shop.lua
@@ -294,14 +294,14 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 					if xPlayer.getMoney() >= totalPrice then
 						xPlayer.removeMoney(totalPrice)
 						xPlayer.addInventoryItem(item, count)
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'success',
 							duration  =  5500,
 							message = _U('item_added')..count.." "..list[i].label,
 							sound  =  true
 						})
 					else
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'error',
 							duration  =  5500,
 							message = _U('no_money'),
@@ -311,7 +311,7 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 				end
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('insufficient_space'),
@@ -328,14 +328,14 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 					if xPlayer.getMoney() >= totalPrice then
 						xPlayer.removeMoney(totalPrice)
 						xPlayer.addInventoryItem(item, count)
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'success',
 							duration  =  5500,
 							message = _U('item_added')..count.." "..list[i].label,
 							sound  =  true
 						})
 					else
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'error',
 							duration  =  5500,
 							message = _U('no_money'),
@@ -345,7 +345,7 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 				end
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('insufficient_space'),
@@ -366,14 +366,14 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 					if xPlayer.getMoney() >= totalPrice then
 						xPlayer.removeMoney(totalPrice)
 						TriggerClientEvent("DP_Inventory:AddAmmoToWeapon", source, list[i].weaponhash, ammo)
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'succes',
 							duration  =  5500,
 							message = _U('item_added')..count.." "..list[i].label,
 							sound  =  true
 						})
 					else
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'error',
 							duration  =  5500,
 							message = _U('no_money'),
@@ -381,7 +381,7 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 						})
 					end
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('insufficient_space'),
@@ -417,7 +417,7 @@ ESX.RegisterServerCallback('DP_Inventory:buyLicense', function(source, cb)
 			cb(true)
 		end)
 	else
-		TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+		TriggerClientEvent('t-notify:client:Alert', _source, {
 			style  =  'success',
 			duration  =  5500,
 			message = _U("no_money"),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/shop.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/shop.lua
@@ -295,27 +295,27 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 						xPlayer.removeMoney(totalPrice)
 						xPlayer.addInventoryItem(item, count)
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'success',
-							duration  =  5500,
-							message = _U('item_added')..count.." "..list[i].label,
-							sound  =  true
+							style  		=  'success',
+							duration  	=  5500,
+							message 	= _U('item_added')..count.." "..list[i].label,
+							sound  		=  true
 						})
 					else
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'error',
-							duration  =  5500,
-							message = _U('no_money'),
-							sound  =  true
+							style  		=  'error',
+							duration  	=  5500,
+							message 	= _U('no_money'),
+							sound  		=  true
 						})
 					end
 				end
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('insufficient_space'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('insufficient_space'),
+				sound  		=  true
 			})
 		end
 	end
@@ -329,27 +329,27 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 						xPlayer.removeMoney(totalPrice)
 						xPlayer.addInventoryItem(item, count)
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'success',
-							duration  =  5500,
-							message = _U('item_added')..count.." "..list[i].label,
-							sound  =  true
+							style  		=  'success',
+							duration  	=  5500,
+							message 	= _U('item_added')..count.." "..list[i].label,
+							sound  		=  true
 						})
 					else
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'error',
-							duration  =  5500,
-							message = _U('no_money'),
-							sound  =  true
+							style  		=  'error',
+							duration  	=  5500,
+							message 	= _U('no_money'),
+							sound  		=  true
 						})
 					end
 				end
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('insufficient_space'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('insufficient_space'),
+				sound  		=  true
 			})
 		end
 	end
@@ -367,25 +367,25 @@ AddEventHandler("DP_Inventory:SellItemToPlayer",function(source, type, item, cou
 						xPlayer.removeMoney(totalPrice)
 						TriggerClientEvent("DP_Inventory:AddAmmoToWeapon", source, list[i].weaponhash, ammo)
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'succes',
-							duration  =  5500,
-							message = _U('item_added')..count.." "..list[i].label,
-							sound  =  true
+							style  		=  'succes',
+							duration  	=  5500,
+							message 	= _U('item_added')..count.." "..list[i].label,
+							sound  		=  true
 						})
 					else
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'error',
-							duration  =  5500,
-							message = _U('no_money'),
-							sound  =  true
+							style  		=  'error',
+							duration  	=  5500,
+							message 	= _U('no_money'),
+							sound  		=  true
 						})
 					end
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('insufficient_space'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('insufficient_space'),
+						sound  		=  true
 					})
 				end
 			end
@@ -418,10 +418,10 @@ ESX.RegisterServerCallback('DP_Inventory:buyLicense', function(source, cb)
 		end)
 	else
 		TriggerClientEvent('t-notify:client:Alert', _source, {
-			style  =  'success',
-			duration  =  5500,
-			message = _U("no_money"),
-			sound  =  true
+			style  		=  'success',
+			duration  	=  5500,
+			message 	= _U("no_money"),
+			sound  		=  true
 		})
 		cb(false)
 	end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
@@ -240,10 +240,10 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 							break
 						else
 							TriggerClientEvent('t-notify:client:Alert', _source, {
-								style  =  'success',
-								duration  =  5500,
-								message = _U("invalid_quantity"),
-								sound  =  true
+								style  		=  'success',
+								duration  	=  5500,
+								message 	= _U("invalid_quantity"),
+								sound  		=  true
 							})
 						end
 					end
@@ -280,10 +280,10 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("player_inv_no_space"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("player_inv_no_space"),
+				sound  		=  true
 			})
 		end
 	end
@@ -324,10 +324,10 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 				TriggerClientEvent("DP_Inventory:refreshTrunkInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'success',
-					duration  =  5500,
-					message = _U("invalid_amount"),
-					sound  =  true
+					style  		=  'success',
+					duration  	=  5500,
+					message 	= _U("invalid_amount"),
+					sound  		=  true
 				})
 			end
 		end)
@@ -408,10 +408,10 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				end
 				if (getTotalInventoryWeightTrunk(plate) + (getItemWeight(item) * count)) > max then
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  5500,
-						message = _U("insufficient_space"),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  5500,
+						message	 	= _U("insufficient_space"),
+						sound  		=  true
 					})
 				else
 					store.set("coffre", coffre)
@@ -451,10 +451,10 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				end
 				if (getTotalInventoryWeightTrunk(plate) + (count / 10)) > max then
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  5500,
-						message = _U("insufficient_space"),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  5500,
+						message 	= _U("insufficient_space"),
+						sound  		=  true
 					})
 				else
 					xPlayer.removeAccountMoney(item, count)
@@ -467,10 +467,10 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("invalid_amount"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("invalid_amount"),
+				sound  		=  true
 			})
 		end
 	end
@@ -491,10 +491,10 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				if (getTotalInventoryWeightTrunk(plate) + (count / 10)) > max then
 
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  5500,
-						message = _U("insufficient_space"),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  5500,
+						message 	= _U("insufficient_space"),
+						sound  		=  true
 					})
 				else
 					xPlayer.removeMoney(count)
@@ -507,10 +507,10 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'success',
-				duration  =  5500,
-				message = _U("invalid_amount"),
-				sound  =  true
+				style  		=  'success',
+				duration  	=  5500,
+				message 	= _U("invalid_amount"),
+				sound  		=  true
 			})
 		end
 	end

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
@@ -368,12 +368,10 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 				data = {plate = plate, max = max, myVeh = owned, text = text}
 				TriggerClientEvent("DP_Inventory:refreshTrunkInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			else
-				TriggerClientEvent("pNotify:SendNotification", _source, {
-					text = _U("invalid_amount"),
-					type = "error",
-					queue = "trunk",
-					timeout = 3000,
-					layout = "bottomCenter"
+				TriggerClientEvent('t-notify:client:Alert', _source, {
+					style 		=  'error',
+					duration 	=  5500,
+					message 	= _U("invalid_amount"),
 				})
 			end
 		end)

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
@@ -239,7 +239,7 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 							end
 							break
 						else
-							TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+							TriggerClientEvent('t-notify:client:Alert', _source, {
 								style  =  'success',
 								duration  =  5500,
 								message = _U("invalid_quantity"),
@@ -279,7 +279,7 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 				TriggerClientEvent("DP_Inventory:refreshTrunkInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("player_inv_no_space"),
@@ -323,7 +323,7 @@ AddEventHandler("DP_Inventory_trunk:getItem", function(plate, type, item, count,
 				data = {plate = plate, max = max, myVeh = owned, text = text}
 				TriggerClientEvent("DP_Inventory:refreshTrunkInventory", _source, data, blackMoney, cashMoney, items, weapons)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'success',
 					duration  =  5500,
 					message = _U("invalid_amount"),
@@ -407,7 +407,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 					})
 				end
 				if (getTotalInventoryWeightTrunk(plate) + (getItemWeight(item) * count)) > max then
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  5500,
 						message = _U("insufficient_space"),
@@ -429,7 +429,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_quantity"),
@@ -450,7 +450,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 					table.insert(blackMoney, {amount = count})
 				end
 				if (getTotalInventoryWeightTrunk(plate) + (count / 10)) > max then
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  5500,
 						message = _U("insufficient_space"),
@@ -466,7 +466,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_amount"),
@@ -490,7 +490,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 
 				if (getTotalInventoryWeightTrunk(plate) + (count / 10)) > max then
 
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  5500,
 						message = _U("insufficient_space"),
@@ -506,7 +506,7 @@ AddEventHandler("DP_Inventory_trunk:putItem", function(plate, type, item, count,
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'success',
 				duration  =  5500,
 				message = _U("invalid_amount"),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/vault.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/vault.lua
@@ -11,7 +11,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				local inventoryItem = inventory.getItem(item)
 				if count > 0 and inventoryItem.count >= count then
 					if not xPlayer.canCarryItem(item, count) then
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'error',
 							duration  =  5500,
 							message = _U('player_cannot_hold'),
@@ -20,7 +20,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					else
 						inventory.removeItem(item, count)
 						xPlayer.addInventoryItem(item, count)
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'success',
 							duration  =  7500,
 							message = _U('have_withdrawn', count, inventoryItem.label),
@@ -28,7 +28,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 						})
 					end
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('not_enough_in_vault'),
@@ -56,7 +56,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				local inventoryItem = inventory.getItem(item)
 				if count > 0 and inventoryItem.count >= count then
 					if not xPlayer.canCarryItem(item, count) then
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'error',
 							duration  =  5500,
 							message = _U('player_cannot_hold'),
@@ -65,7 +65,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					else
 						inventory.removeItem(item, count)
 						xPlayer.addInventoryItem(item, count)
-						TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+						TriggerClientEvent('t-notify:client:Alert', _source, {
 							style  =  'success',
 							duration  =  8500,
 							message = _U('have_withdrawn', count, inventoryItem.label),
@@ -73,7 +73,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 						})
 					end
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('not_enough_in_vault'),
@@ -92,7 +92,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('amount_invalid'),
@@ -107,7 +107,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('amount_invalid'),
@@ -132,7 +132,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'error',
 						duration  =  5500,
 						message = _U('amount_invalid'),
@@ -141,7 +141,7 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				end
 			end)
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('no_permissions'),
@@ -165,7 +165,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				TriggerEvent('esx_addoninventory:getSharedInventory', 'society_'..job, function(inventory)
 					xPlayer.removeInventoryItem(item, count)
 					inventory.addItem(item, count)
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  7500,
 						message = _U('have_deposited', count, inventory.getItem(item).label),
@@ -182,7 +182,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				TriggerEvent('esx_addoninventory:getInventory', 'vault', xPlayerOwner.identifier, function(inventory)
 					xPlayer.removeInventoryItem(item, count)
 					inventory.addItem(item, count)
-					TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+					TriggerClientEvent('t-notify:client:Alert', _source, {
 						style  =  'success',
 						duration  =  7500,
 						message = _U('have_deposited', count, inventory.getItem(item).label),
@@ -190,7 +190,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 					})
 				end)
 			else
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('no_permissions'),
@@ -198,7 +198,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				})
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('invalid_quantity'),
@@ -228,7 +228,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				end)
 			else
 				xPlayer.addAccountMoney(item, count)
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('no_permissions'),
@@ -236,7 +236,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				})
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('amount_invalid'),
@@ -265,7 +265,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				end)
 			else
 				xPlayer.addAccountMoney(item, count)
-				TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+				TriggerClientEvent('t-notify:client:Alert', _source, {
 					style  =  'error',
 					duration  =  5500,
 					message = _U('no_permissions'),
@@ -273,7 +273,7 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 				})
 			end
 		else
-			TriggerClientEvent('tnotify:client:SendTextAlert', _source, {
+			TriggerClientEvent('t-notify:client:Alert', _source, {
 				style  =  'error',
 				duration  =  5500,
 				message = _U('amount_invalid'),

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/vault.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/vault.lua
@@ -12,27 +12,27 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				if count > 0 and inventoryItem.count >= count then
 					if not xPlayer.canCarryItem(item, count) then
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'error',
-							duration  =  5500,
-							message = _U('player_cannot_hold'),
-							sound  =  true
+							style  		=  'error',
+							duration  	=  5500,
+							message 	= _U('player_cannot_hold'),
+							sound  		=  true
 						})
 					else
 						inventory.removeItem(item, count)
 						xPlayer.addInventoryItem(item, count)
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'success',
-							duration  =  7500,
-							message = _U('have_withdrawn', count, inventoryItem.label),
-							sound  =  true
+							style  		=  'success',
+							duration  	=  7500,
+							message 	= _U('have_withdrawn', count, inventoryItem.label),
+							sound  		=  true
 						})
 					end
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('not_enough_in_vault'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('not_enough_in_vault'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -41,14 +41,26 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				local inventoryItem = inventory.getItem(item)
 				if count > 0 and inventoryItem.count >= count then
 					if not xPlayer.canCarryItem(item, count) then
-						TriggerClientEvent('mythic_notify:client:SendAlert', _source, {type = 'error', text = _U('player_cannot_hold'), length = 5500})
+						TriggerClientEvent('t-notify:client:Alert', _source, {
+                            style  		=  'error',
+                            duration  	=  5500,
+                            message 	= _U('player_cannot_hold'),
+                        })
 					else
 						inventory.removeItem(item, count)
 						xPlayer.addInventoryItem(item, count)
-						TriggerClientEvent('mythic_notify:client:SendAlert', _source, {type = 'success', text = _U('have_withdrawn', count, inventoryItem.label), length = 7500})
+						TriggerClientEvent('t-notify:client:Alert', _source, {
+                            style  		=  'success',
+                            duration  	=  7500,
+                            message 	= _U('have_withdrawn', count, inventoryItem.label),
+                        })
 					end
 				else
-					TriggerClientEvent('mythic_notify:client:SendAlert', _source, {type = 'error', text = _U('not_enough_in_vault'), length = 5500})
+					TriggerClientEvent('t-notify:client:Alert', _source, {
+                        style  		=  'error',
+                        duration  	=  5500,
+                        message 	= _U('not_enough_in_vault'),
+                    })					
 				end
 			end)]]
 		elseif job == 'vault' then
@@ -57,27 +69,27 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 				if count > 0 and inventoryItem.count >= count then
 					if not xPlayer.canCarryItem(item, count) then
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'error',
-							duration  =  5500,
-							message = _U('player_cannot_hold'),
-							sound  =  true
+							style  		=  'error',
+							duration  	=  5500,
+							message 	= _U('player_cannot_hold'),
+							sound  		=  true
 						})
 					else
 						inventory.removeItem(item, count)
 						xPlayer.addInventoryItem(item, count)
 						TriggerClientEvent('t-notify:client:Alert', _source, {
-							style  =  'success',
-							duration  =  8500,
-							message = _U('have_withdrawn', count, inventoryItem.label),
-							sound  =  true
+							style  		=  'success',
+							duration  	=  8500,
+							message 	= _U('have_withdrawn', count, inventoryItem.label),
+							sound  		=  true
 						})
 					end
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('not_enough_in_vault'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('not_enough_in_vault'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -93,10 +105,10 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					xPlayer.addAccountMoney(item, count)
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('amount_invalid'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('amount_invalid'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -108,10 +120,10 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					xPlayer.addAccountMoney(item, count)
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('amount_invalid'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('amount_invalid'),
+						sound  		=  true
 					})
 				end
 			end)
@@ -122,7 +134,12 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					account.removeMoney(count)
 					xPlayer.addAccountMoney(item, count)
 				else
-					TriggerClientEvent('mythic_notify:client:SendAlert', _source, {type = 'error', text = _U('amount_invalid'), length = 5500})
+					TriggerClientEvent('t-notify:client:Alert', _source, {
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('amount_invalid'),
+						sound  		=  true
+					})					
 				end
 			end)]]
 		elseif job == 'vault' then
@@ -133,19 +150,19 @@ AddEventHandler('DP_Inventory:getItem', function(--[[owner,--]] job, type, item,
 					xPlayer.addAccountMoney(item, count)
 				else
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'error',
-						duration  =  5500,
-						message = _U('amount_invalid'),
-						sound  =  true
+						style  		=  'error',
+						duration  	=  5500,
+						message 	= _U('amount_invalid'),
+						sound  		=  true
 					})
 				end
 			end)
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('no_permissions'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('no_permissions'),
+				sound  		=  true
 			})
 		end
 	end
@@ -166,43 +183,48 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 					xPlayer.removeInventoryItem(item, count)
 					inventory.addItem(item, count)
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  7500,
-						message = _U('have_deposited', count, inventory.getItem(item).label),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  7500,
+						message 	= _U('have_deposited', count, inventory.getItem(item).label),
+						sound  		=  true
 					})
 				end)
 			--[[elseif xPlayer.club.name == job then
 				TriggerEvent('esx_addoninventory:getSharedInventory', 'society_'.. job, function(inventory)
 					xPlayer.removeInventoryItem(item, count)
 					inventory.addItem(item, count)
-					TriggerClientEvent('mythic_notify:client:SendAlert', _source, {type = 'success', text = _U('have_deposited', count, inventory.getItem(item).label), length = 7500})
+					TriggerClientEvent('t-notify:client:Alert', _source, {
+						style  		=  'success',
+						duration  	=  7500,
+						message 	= _U('have_deposited', count, inventory.getItem(item).label),
+						sound  		=  true
+					})
 				end)]]
 			elseif job == 'vault' then
 				TriggerEvent('esx_addoninventory:getInventory', 'vault', xPlayerOwner.identifier, function(inventory)
 					xPlayer.removeInventoryItem(item, count)
 					inventory.addItem(item, count)
 					TriggerClientEvent('t-notify:client:Alert', _source, {
-						style  =  'success',
-						duration  =  7500,
-						message = _U('have_deposited', count, inventory.getItem(item).label),
-						sound  =  true
+						style  		=  'success',
+						duration  	=  7500,
+						message 	= _U('have_deposited', count, inventory.getItem(item).label),
+						sound  		=  true
 					})
 				end)
 			else
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('no_permissions'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('no_permissions'),
+					sound  		=  true
 				})
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('invalid_quantity'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('invalid_quantity'),
+				sound  		=  true
 			})
 		end
 
@@ -229,18 +251,18 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 			else
 				xPlayer.addAccountMoney(item, count)
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('no_permissions'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('no_permissions'),
+					sound  		=  true
 				})
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('amount_invalid'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('amount_invalid'),
+				sound  		=  true
 			})
 		end
 	elseif type == 'item_money' then
@@ -266,18 +288,18 @@ AddEventHandler('DP_Inventory:putItem', function(--[[owner,--]] job, type, item,
 			else
 				xPlayer.addAccountMoney(item, count)
 				TriggerClientEvent('t-notify:client:Alert', _source, {
-					style  =  'error',
-					duration  =  5500,
-					message = _U('no_permissions'),
-					sound  =  true
+					style  		=  'error',
+					duration  	=  5500,
+					message 	= _U('no_permissions'),
+					sound  		=  true
 				})
 			end
 		else
 			TriggerClientEvent('t-notify:client:Alert', _source, {
-				style  =  'error',
-				duration  =  5500,
-				message = _U('amount_invalid'),
-				sound  =  true
+				style  		=  'error',
+				duration  	=  5500,
+				message 	= _U('amount_invalid'),
+				sound  		=  true
 			})
 		end
 	end


### PR DESCRIPTION
The notification methods used previously were depreciated as of the latest version of t-notify `1.42` and would result in an error. 
![image](https://user-images.githubusercontent.com/55056068/116802438-b0c48f00-aae0-11eb-805f-c644f1ba043c.png)

This PR addresses that and also removes some left over notifications for mythic, b1g_notify and pNotify.

Please squash if you decide to merge please.

