### PR TITLE
Performance fix for opening trunks and gloveboxes

### DIFF
--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/glovebox.lua
@@ -44,37 +44,31 @@ function loadInventGloveboxGlovebox(plate)
 	end
 end
 
-function getOwnedVehicle(plate)
+function getOwnedVehicleGlove(plate)
+
 	local found = false
 	if listPlate then
 		for k, v in pairs(listPlate) do
 			if string.find(plate, v) ~= nil then
-			found = true
-			break
+				found = true
+				break
 			end
 		end
 	end
-	if not found then
-		local result = MySQL.Sync.fetchAll("SELECT * FROM owned_vehicles")
-		while result == nil do
-			Wait(5)
-		end
-		if result ~= nil and #result > 0 then
-			for _, v in pairs(result) do
-			local vehicle = json.decode(v.vehicle)
-				if vehicle.plate == plate then
-					found = true
-					break
-				end
-			end
-		end
+
+	if found == true then
+		return found
 	end
-	return found
+
+	local result = MySQL.Sync.fetchAll("SELECT plate FROM owned_vehicles WHERE plate = @plate", {
+		['@plate'] = plate
+	})
+	return #result > 0
 end
 
 function MakeDataStoreGlovebox(plate)
 	local data = {}
-	local owned = getOwnedVehicle(plate)
+	local owned = getOwnedVehicleGlove(plate)
 	local dataStore = CreateDataStoreGlovebox(plate, owned, data)
 	SharedDataStores[plate] = dataStore
 	MySQL.Async.execute("INSERT INTO inventory_glovebox(plate,data,owned) VALUES (@plate,'{}',@owned)", {

--- a/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
+++ b/ESX/Inventory HUD/ESX v1.2 (v1-final)/DP_Inventory/server/trunk.lua
@@ -43,7 +43,7 @@ function loadInventTrunk(plate)
 	end
 end
 
-function getOwnedVehicle(plate)
+function getOwnedVehicleTrunk(plate)
 	local found = false
 	if listPlate then
 		for k, v in pairs(listPlate) do
@@ -53,27 +53,20 @@ function getOwnedVehicle(plate)
 			end
 		end
 	end
-	if not found then
-		local result = MySQL.Sync.fetchAll("SELECT * FROM owned_vehicles")
-		while result == nil do
-			Wait(5)
-		end
-		if result ~= nil and #result > 0 then
-			for _, v in pairs(result) do
-				local vehicle = json.decode(v.vehicle)
-				if vehicle.plate == plate then
-				found = true
-				break
-				end
-			end
-		end
+
+	if found == true then
+		return found
 	end
-	return found
+
+	local result = MySQL.Sync.fetchAll("SELECT plate FROM owned_vehicles WHERE plate = @plate", {
+		['@plate'] = plate
+	})
+	return #result > 0
 end
 
 function MakeDataStoreTrunk(plate)
 	local data = {}
-	local owned = getOwnedVehicle(plate)
+	local owned = getOwnedVehicleTrunk(plate)
 	local dataStore = CreateDataStoreTrunk(plate, owned, data)
 	SharedDataStores[plate] = dataStore
 	MySQL.Async.execute("INSERT INTO inventory_trunk(plate,data,owned) VALUES (@plate,'{}',@owned)", {


### PR DESCRIPTION
There were a couple of issues to address. Firstly, the same function was defined in two locations. Repetition seems to be a design goal in this project. Given potential regression I opted to just leave the two functions in and let it be, but I renamed the functions to stop overlap.

**Explanation**
getOwnedVehicle(plate) is currently defined in the trunk and glovebox files. We had an error when opening trunks where plate was going in as null and when it drilled down to the getOwnedVehicle(plate) call the glovebox one was being called. Wrong given it was called from trunk.lua. I suspect the because g comes before t, lua is just resolving the duplicated definiton in glovebox.lua over the one just above it in the same trunk.lua file. The better option would be to define another common lua file and add to the fxmanifest but I just decided to rename the two functions to ensure the correct one is being called.

**Performance Fix**
Opening trunks and gloveboxes in our city has been progessively getting slower over the 10 months we've been live and this is the reason. The old design for the getOwnedVehicle function is ridiculously bloated. You fetch EVERY row and column from owned_vehicles and then use the most inefficient approach to find the vehicle by plate:
* Loop through every row
* Json decode each row to get the plate (this json serialiser is crazy slow)
* Compare and break if found.

So our city has in excess of 8000 vehicles, for explanation purposes say there's exactly 8000. You pull back the entire table in order to compare one column in lua, so for starters you should do ```SELECT vehicle FROM ...```, THEN loop over all rows. Best case possible is you have the overhead of pulling back all rows and the one requested is first in the list. Worst case is you have the overhead of pulling back all rows and the one requested is last in the list...that's 8000 json decodes to find a single vehicle. There are JSON type functions in MySQL and MariaDB which could be used in the query to compare the plate property of the JSON on the database side very efficiently saving overhead in the fxserver. But you don't even need that because there's a column on the database called **plate**.

My solution here is to query against the plate column to return only the row from the table specifically for the vehicle in question using ```WHERE plate = @plate```. There is absolutely no need for any of the columns to come back, you could do ```SELECT COUNT(plate) FROM ...``` which would give 0 or 1 as the scalar result of rh query, but I went with returning the plate column. Because in the case we either get a result set of an empty lua table or a single entry, we can return true or false based on whether ```#result > 0```.

If comparing by the plate column is an issue then I'll rework the query to go with a database side JSON function to cater for MariaDB and MySQL. esx_vehicleshop adds the plate column, so I'm assuming the plate column will always be there.

